### PR TITLE
Fix price modifier setting group name

### DIFF
--- a/modules/price-modifier/price-modifier.php
+++ b/modules/price-modifier/price-modifier.php
@@ -110,7 +110,7 @@ class EsistenzePriceModifier {
     
     public function register_settings() {
         register_setting('esistenze_price_modifier', 'esistenze_price_modifier_enabled');
-        register_setting('esistenza_price_modifier', 'esistenze_price_note');
+        register_setting('esistenze_price_modifier', 'esistenze_price_note');
         register_setting('esistenze_price_modifier', 'esistenze_price_note_color');
         register_setting('esistenze_price_modifier', 'esistenze_price_bg_color');
         register_setting('esistenze_price_modifier', 'esistenze_price_border_color');


### PR DESCRIPTION
## Summary
- fix plugin settings registration group names

## Testing
- `find modules -name "*.php" | xargs -I{} php -l {}` *(fails: `php: No such file or directory`)*
- `npm test` *(fails: `ENOENT Could not read package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685d37e5a2008332a82c59c084c06a13