### PR TITLE
Enable capability filter for Quick Menu Cards

### DIFF
--- a/modules/quick-menu-cards/includes/class-admin.php
+++ b/modules/quick-menu-cards/includes/class-admin.php
@@ -18,7 +18,7 @@ class EsistenzeQuickMenuCardsAdmin {
     public function __construct($module_path, $module_url) {
         $this->module_path = $module_path;
         $this->module_url = $module_url;
-        $this->capability = 'manage_options';
+        $this->capability = esistenze_qmc_capability();
         $this->page_hooks = array();
         $this->init_hooks();
     }

--- a/modules/quick-menu-cards/includes/class-ajax.php
+++ b/modules/quick-menu-cards/includes/class-ajax.php
@@ -32,7 +32,7 @@ class EsistenzeQuickMenuCardsAjax {
     
     public function save_card_group() {
         // Nonce ve yetki kontrolü
-        if (!$this->verify_nonce() || !current_user_can('manage_options')) {
+        if (!$this->verify_nonce() || !current_user_can(esistenze_qmc_capability())) {
             wp_send_json_error('Yetkisiz erişim.');
         }
         
@@ -79,7 +79,7 @@ class EsistenzeQuickMenuCardsAjax {
     }
     
     public function delete_card_group() {
-        if (!$this->verify_nonce() || !current_user_can('manage_options')) {
+        if (!$this->verify_nonce() || !current_user_can(esistenze_qmc_capability())) {
             wp_send_json_error('Yetkisiz erişim.');
         }
         
@@ -115,7 +115,7 @@ class EsistenzeQuickMenuCardsAjax {
     }
     
     public function duplicate_card_group() {
-        if (!$this->verify_nonce() || !current_user_can('manage_options')) {
+        if (!$this->verify_nonce() || !current_user_can(esistenze_qmc_capability())) {
             wp_send_json_error('Yetkisiz erişim.');
         }
         
@@ -161,7 +161,7 @@ class EsistenzeQuickMenuCardsAjax {
     }
     
     public function export_groups() {
-        if (!$this->verify_nonce() || !current_user_can('manage_options')) {
+        if (!$this->verify_nonce() || !current_user_can(esistenze_qmc_capability())) {
             wp_send_json_error('Yetkisiz erişim.');
         }
         
@@ -185,7 +185,7 @@ class EsistenzeQuickMenuCardsAjax {
     }
     
     public function import_groups() {
-        if (!$this->verify_nonce() || !current_user_can('manage_options')) {
+        if (!$this->verify_nonce() || !current_user_can(esistenze_qmc_capability())) {
             wp_send_json_error('Yetkisiz erişim.');
         }
         

--- a/modules/quick-menu-cards/includes/class-shortcodes.php
+++ b/modules/quick-menu-cards/includes/class-shortcodes.php
@@ -111,7 +111,7 @@ class EsistenzeQuickMenuCardsShortcodes {
      * Handle preview mode
      */
     public function handle_preview_mode() {
-        if (!isset($_GET['quick_menu_preview']) || !is_admin() || !current_user_can('manage_options')) {
+        if (!isset($_GET['quick_menu_preview']) || !is_admin() || !current_user_can(esistenze_qmc_capability())) {
             return;
         }
         

--- a/modules/quick-menu-cards/quick-menu-cards.php
+++ b/modules/quick-menu-cards/quick-menu-cards.php
@@ -8,6 +8,12 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+if (!function_exists('esistenze_qmc_capability')) {
+    function esistenze_qmc_capability() {
+        return apply_filters('esistenze_quick_menu_capability', 'manage_options');
+    }
+}
+
 class EsistenzeQuickMenuCards {
     
     private static $instance = null;

--- a/modules/quick-menu-cards/views/admin-tools.php
+++ b/modules/quick-menu-cards/views/admin-tools.php
@@ -24,7 +24,7 @@ add_action('wp_ajax_esistenze_clear_debug_log', 'esistenze_handle_clear_debug_lo
 add_action('wp_ajax_esistenze_download_system_info', 'esistenze_handle_download_system_info');
 
 function esistenze_handle_export_data() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -73,7 +73,7 @@ function esistenze_handle_export_data() {
 }
 
 function esistenze_handle_import_data() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -200,7 +200,7 @@ function esistenze_handle_import_data() {
 }
 
 function esistenze_handle_clear_cache() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -287,7 +287,7 @@ function esistenze_preload_cache() {
 }
 
 function esistenze_handle_db_action() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -371,7 +371,7 @@ function esistenze_cleanup_old_data() {
 }
 
 function esistenze_handle_check_error_log() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -426,7 +426,7 @@ function esistenze_handle_check_error_log() {
 }
 
 function esistenze_handle_test_conflicts() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -490,7 +490,7 @@ function esistenze_handle_test_conflicts() {
 }
 
 function esistenze_handle_performance_test() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -545,7 +545,7 @@ function esistenze_handle_performance_test() {
 }
 
 function esistenze_handle_maintenance_mode() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -576,7 +576,7 @@ function esistenze_handle_maintenance_mode() {
 }
 
 function esistenze_handle_get_debug_log() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -624,7 +624,7 @@ function esistenze_handle_get_debug_log() {
 }
 
 function esistenze_handle_clear_debug_log() {
-    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_POST['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_send_json_error('Yetkisiz erişim.');
     }
     
@@ -646,7 +646,7 @@ function esistenze_handle_clear_debug_log() {
 }
 
 function esistenze_handle_download_system_info() {
-    if (!wp_verify_nonce($_GET['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can('manage_options')) {
+    if (!wp_verify_nonce($_GET['nonce'], 'esistenze_quick_menu_nonce') || !current_user_can(esistenze_qmc_capability())) {
         wp_die('Yetkisiz erişim.');
     }
     
@@ -743,7 +743,7 @@ add_action('template_redirect', 'esistenze_check_maintenance_mode');
 
 function esistenze_check_maintenance_mode() {
     // Admin kullanıcıları bakım modundan muaf
-    if (current_user_can('manage_options')) {
+    if (current_user_can(esistenze_qmc_capability())) {
         return;
     }
     


### PR DESCRIPTION
## Summary
- allow overriding Quick Menu Cards admin capability with a new filter
- replace hardcoded `manage_options` checks with `esistenze_qmc_capability()`

## Testing
- `php -l modules/quick-menu-cards/quick-menu-cards.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4f2490fc83328762597acd88c083