### PR TITLE
Add row deletion feature

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -153,13 +153,15 @@
     background: #F57C00 !important;
 }
 
-.delete-button {
+.delete-button,
+.delete-btn {
     background: #f44336 !important;
     color: white !important;
     border-color: #f44336 !important;
 }
 
-.delete-button:hover {
+.delete-button:hover,
+.delete-btn:hover {
     background: #d32f2f !important;
 }
 

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -13,11 +13,25 @@ jQuery(document).ready(function($) {
     );
     
     // Smart Buttons functionality
+    function updateRowIndices() {
+        $('.sortable-button-list tr').each(function(index) {
+            $(this).attr('data-index', index);
+            $(this).find('input, select').each(function () {
+                var name = $(this).attr('name');
+                if (name) {
+                    var newName = name.replace(/\[\d+\]/, '[' + index + ']');
+                    $(this).attr('name', newName);
+                }
+            });
+        });
+    }
+
     if ($('.sortable-button-list').length) {
         $('.sortable-button-list').sortable({
             update: function(event, ui) {
                 var order = $(this).sortable('toArray', { attribute: 'data-index' });
                 console.log('New order:', order);
+                updateRowIndices();
             }
         });
     }
@@ -42,6 +56,7 @@ jQuery(document).ready(function($) {
         });
 
         $('.sortable-button-list').append(newRow);
+        updateRowIndices();
     });
 
     // Duplicate button functionality
@@ -57,7 +72,17 @@ jQuery(document).ready(function($) {
             }
         });
 
+
         $('.sortable-button-list').append(clone);
+        updateRowIndices();
+    });
+
+    // Delete button functionality
+    $(document).on('click', '.delete-btn', function () {
+        if (confirm('Bu satırı silmek istediğinize emin misiniz?')) {
+            $(this).closest('tr').remove();
+            updateRowIndices();
+        }
     });
 
     // Preview button functionality


### PR DESCRIPTION
## Summary
- add `updateRowIndices` helper and call it on sort/update
- support adding and duplicating rows with automatic reindexing
- add delete button support
- update CSS to style `.delete-btn`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d63e625388332974306cfe76ad817